### PR TITLE
pyprophet: support for MAYU export

### DIFF
--- a/pyprophet/config.py
+++ b/pyprophet/config.py
@@ -50,6 +50,10 @@ def standard_config(n_cpus=1):
     CONFIG["apply"] = None
     info["apply"] = r"""[name of *_scorer.bin file of existing classifier]"""
 
+    CONFIG["export.mayu"] = False
+    info["export.mayu"] =\
+        """Export input files for MAYU"""
+
     return CONFIG, info
 
 CONFIG, __ = standard_config()

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -11,7 +11,7 @@ except:
 
 from pyprophet import PyProphet
 from config import standard_config, fix_config_types
-from report import save_report
+from report import save_report, export_mayu
 import sys
 import time
 import warnings
@@ -135,6 +135,9 @@ def _main(args):
                     qvalues="_qvalues.txt",
                     d_scores_top_target_peaks="_dscores_top_target_peaks.txt",
                     d_scores_top_decoy_peaks="_dscores_top_decoy_peaks.txt",
+                    mayu_cutoff="_mayu.cutoff",
+                    mayu_fasta="_mayu.fasta",
+                    mayu_csv="_mayu.csv",
     )
 
     if not apply_existing_scorer:
@@ -199,6 +202,12 @@ def _main(args):
         with open(pickled_scorer_path, "wb") as fp:
             fp.write(bin_data)
         print "WRITTEN: ", pickled_scorer_path
+
+    if CONFIG.get("export.mayu", True):
+        export_mayu(pathes.mayu_cutoff, pathes.mayu_fasta, pathes.mayu_csv, scored_table, final_stat)
+        print "WRITTEN: ", pathes.mayu_cutoff
+        print "WRITTEN: ", pathes.mayu_fasta
+        print "WRITTEN: ", pathes.mayu_csv
     print
 
     seconds = int(needed)


### PR DESCRIPTION
This pull request enables MAYU export functionality for pyprophet.

The flag --export.mayu generates three files: A FASTA based on all extracted peptides, a result table in MAYU format with 1 - m_score as discriminant score, and a cutoff file with the target - decoy ratio as parameter for MAYU.

MAYU can be run afterwards as following:
Mayu.pl -B test_mayu.csv -C test_mayu.fasta -E DECOY -runR -PmFDR -P protFDR=0.05:t -H 200 -G 0.20 -F $(cat test_mayu.cutoff)
